### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/LukeFrankio/TakumCpp/security/code-scanning/4](https://github.com/LukeFrankio/TakumCpp/security/code-scanning/4)

To fix this issue, you should add an explicit `permissions` block to limit the `GITHUB_TOKEN` permissions for the workflow/job. The minimal required permissions for a typical CI job like this are usually `contents: read`, which allows the workflow to check out code but not write to the repository. Since the workflow does not perform any action requiring more rights (e.g., no deployment, no issue triaging, etc.), this should suffice. The `permissions` block can be added either at the root of the workflow (affecting all jobs) or inside each job individually. For clarity and maintainability, adding it at the top of the workflow (after `name` and before or after `on`) is best.

Specifically, insert:
```yaml
permissions:
  contents: read
```
near the top of `.github/workflows/ci.yml`, after `name: CI` and before/after the `on:` block.

No imports or further definitions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
